### PR TITLE
feat(listing): "choice all" filter option for select appearance

### DIFF
--- a/resources/views/components/horizon/filter.blade.php
+++ b/resources/views/components/horizon/filter.blade.php
@@ -28,7 +28,8 @@
         @switch($value["appearance"])
             @case(ListingBlock::VALUE_FILTER_APPEARANCE_SELECT)
                 <select class="select" id="{{ $model }}" name="{{ $model }}" @if (!empty($model)) wire:model="{{ $model }}" @endif>
-                    @if ($withEmpty)
+                    {{-- When a "choice all" is configured it is prepended to $value["choices"] and acts as the neutral option, so the empty placeholder would be redundant. --}}
+                    @if ($withEmpty && empty($value["hasChoiceAll"]))
                         <option value="" selected>
                             {{ $name ?? "Sélectionner" }}
                         </option>

--- a/src/Blocks/Listing/ListingBlock.php
+++ b/src/Blocks/Listing/ListingBlock.php
@@ -285,6 +285,7 @@ class ListingBlock extends AbstractBlock
 						->helperText(__('Laisser vide pour ne pas afficher le choix "Tous"', 'horizon-blocks'))
 						->conditionalLogic([
 							ConditionalLogic::where(self::FIELD_FILTERS_META_APPEARANCE, '==', self::VALUE_FILTER_APPEARANCE_RADIO),
+							ConditionalLogic::where(self::FIELD_FILTERS_META_APPEARANCE, '==', self::VALUE_FILTER_APPEARANCE_SELECT),
 						]);
 				}
 
@@ -308,6 +309,7 @@ class ListingBlock extends AbstractBlock
 					->helperText(__('Laisser vide pour ne pas afficher le choix "Tous"', 'horizon-blocks'))
 					->conditionalLogic([
 						ConditionalLogic::where(self::FIELD_FILTERS_TAX_APPEARANCE, '==', self::VALUE_FILTER_APPEARANCE_RADIO),
+						ConditionalLogic::where(self::FIELD_FILTERS_TAX_APPEARANCE, '==', self::VALUE_FILTER_APPEARANCE_SELECT),
 					]);
 			}
 


### PR DESCRIPTION
## What

Make the **"Choix Tous"** (choice-all) filter option available for the **select** appearance, not only for radio.

## Why

The choice-all field let editors add an "All" entry that resets a filter (shows every result). It was gated to the `radio` appearance only via conditional logic, so select-based filters (the most common case) couldn't offer a labelled "All" option — the neutral option only showed the filter name.

The backend (`Listing::handleChoiceAll()`) already supports any appearance: it prepends the choice, sets it as the default, and `applyFilters()` skips querying when the choice-all value is selected. Only the ACF field visibility and the select rendering needed adjusting.

## Changes

- `src/Blocks/Listing/ListingBlock.php` — extend the conditional logic of both choice-all fields (`FIELD_FILTERS_META_CHOICE_ALL`, `FIELD_FILTERS_TAX_CHOICE_ALL`) so they also show when the appearance is `select` (OR with the existing `radio` condition).
- `resources/views/components/horizon/filter.blade.php` — in the select case, stop rendering the redundant empty placeholder `<option>` when a choice-all is configured (it is already prepended to the choices and acts as the neutral option).

## Notes

- No change to `handleChoiceAll()` / `applyFilters()` — existing behaviour.
- No impact on radio/checkbox/multiselect appearances.
- Backwards compatible: filters without a choice-all value render exactly as before.
