### PR TITLE
fix(listing): guard single-value taxonomy filter against non-scalar value

### DIFF
--- a/src/Livewire/Listing/Listing.php
+++ b/src/Livewire/Listing/Listing.php
@@ -694,7 +694,15 @@ class Listing extends Component
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_SELECT:
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_RADIO:
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_SINGLESELECT:
-                                                $taxQuery->add($taxonomyName, [$value]);
+                                                // Single-value appearances only ever carry a scalar term slug.
+                                                // A non-scalar value can still reach this point when the URL
+                                                // holds a stale array shape (e.g. a legacy checkbox/multiselect
+                                                // link kept after the filter was switched to a single-value
+                                                // appearance); passing it through would build a nested `terms`
+                                                // array and make WP_Term_Query call preg_match() on an array.
+                                                if (is_scalar($value)) {
+                                                    $taxQuery->add($taxonomyName, [$value]);
+                                                }
                                                 break;
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_CHECKBOX:
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_MULTISELECT:


### PR DESCRIPTION
## Problem

A stale/legacy array-shaped URL (e.g. `?filtres[type-of-news][news]=true`) — left over after a filter's appearance was switched from checkbox/multiselect to a single-value appearance — hydrates `filterFields` with an array.

The `SELECT` / `RADIO` / `SINGLESELECT` taxonomy branch in `applyFilters()` wrapped the value as `[$value]` unconditionally. With an array value this builds a nested `terms` array, so `WP_Tax_Query` → `WP_Term_Query` → `sanitize_term` calls `preg_match()` on an array:

```
TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given
wp-includes/formatting.php:1612  →  500 Internal Server Error
```

Note the asymmetry that confirms the bug: the `CHECKBOX`/`MULTISELECT` branch just below already guards with `is_array($value)`, but the single-value branch had no scalar guard.

## Fix

Only add the tax query term when `$value` is scalar. An invalid/stale array value now degrades gracefully to "no filter applied" instead of a 500.

## Verification

Reproduced and fixed end-to-end on woah-regionals-site:
- Array-shaped URL: was 500 → now renders (unfiltered).
- Valid scalar select: still filters correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)