### PR TITLE
fix(listing): normalize Choices.js object value for single-value taxonomy filter

### DIFF
--- a/src/Livewire/Listing/Listing.php
+++ b/src/Livewire/Listing/Listing.php
@@ -694,14 +694,17 @@ class Listing extends Component
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_SELECT:
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_RADIO:
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_SINGLESELECT:
-                                                // Single-value appearances only ever carry a scalar term slug.
-                                                // A non-scalar value can still reach this point when the URL
-                                                // holds a stale array shape (e.g. a legacy checkbox/multiselect
-                                                // link kept after the filter was switched to a single-value
-                                                // appearance); passing it through would build a nested `terms`
-                                                // array and make WP_Term_Query call preg_match() on an array.
-                                                if (is_scalar($value)) {
-                                                    $taxQuery->add($taxonomyName, [$value]);
+                                                // Single-value appearances resolve to a single term slug, but the
+                                                // incoming value isn't always a bare scalar: a Choices.js enhanced
+                                                // <select> bound with wire:model reports its change through
+                                                // Livewire as an object, so $value arrives as ['value' => 'slug'].
+                                                // Normalise both shapes to a scalar slug; passing the raw array to
+                                                // add() would build a nested `terms` array and make WP_Term_Query
+                                                // call preg_match() on an array (500). Anything else is skipped.
+                                                $termSlug = is_array($value) ? ($value['value'] ?? null) : $value;
+
+                                                if (is_scalar($termSlug) && '' !== $termSlug) {
+                                                    $taxQuery->add($taxonomyName, [$termSlug]);
                                                 }
                                                 break;
                                             case ListingBlock::VALUE_FILTER_APPEARANCE_CHECKBOX:


### PR DESCRIPTION
## Problem

Follow-up to #32. A Choices.js enhanced `<select>` bound with `wire:model` reports its selection to Livewire as an **object**, so the filter value arrives as `['value' => 'slug']` rather than a bare scalar.

The `SELECT` / `RADIO` / `SINGLESELECT` taxonomy branch wrapped it as `[$value]`, producing a nested `terms` array → `WP_Term_Query` calls `preg_match()` on an array → **500 on every real selection**.

#32's `is_scalar()` guard stopped the crash but, because the real value is an array, silently **dropped the filter** — selecting a term returned all results (filter dead).

## Fix

Normalize to a scalar term slug before building the tax query:

```php
$termSlug = is_array($value) ? ($value['value'] ?? null) : $value;
if (is_scalar($termSlug) && '' !== $termSlug) {
    $taxQuery->add($taxonomyName, [$termSlug]);
}
```

Unwraps the `['value' => ...]` Choices/Livewire shape, keeps plain scalars (radio), and skips anything else instead of crashing.

## Verification

Reproduced and fixed end-to-end on woah-regionals-site:
- Normal Choices select → value `['value' => 'statement']` → **filters to 3 statements** (was: 500, then 10/10 unfiltered with #32).
- Empty selection → all results, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)