### PR TITLE
fix(action): barre d'ancres — surface sombre du design system et icône du CTA

### DIFF
--- a/resources/styles/blocks/navbar.css
+++ b/resources/styles/blocks/navbar.css
@@ -26,13 +26,16 @@
         ouvert, qui montent plus haut dans les thèmes Horizon.
     */
     .navbar-anchors {
-        @apply bg-neutral-1000 sticky inset-x-0 z-[100] max-lg:hidden;
+        /* Fond en `color-01-50`, résolu par `awc-theme-dark` (posé dans le Blade) en sa valeur
+           sombre. Attention : `neutral-1000` basculerait au blanc sous ce thème. */
+        @apply bg-color-01-50 sticky inset-x-0 z-[100] max-lg:hidden;
 
         top: var(--navbar-anchors-offset, 0px);
     }
 
+    /* 28px (`2xlarge`) entre les ancres et le CTA. */
     .navbar-anchors-inner {
-        @apply gap-x-large flex items-center py-3;
+        @apply flex items-center gap-x-7 py-3;
     }
 
     /*
@@ -56,7 +59,7 @@
         &::after {
             @apply pointer-events-none absolute inset-y-0 right-0 w-12;
 
-            background-image: linear-gradient(to left, var(--color-neutral-1000), transparent);
+            background-image: linear-gradient(to left, var(--color-color-01-50), transparent);
             content: '';
         }
     }
@@ -86,16 +89,22 @@
         @apply inline-flex items-center;
         /* Bordure à 40 % : en dessous, le contour se perd sur le fond sombre. */
         @apply rounded-button border border-solid border-white/40;
-        @apply text-small whitespace-nowrap px-4 py-2 font-semibold text-white;
+        @apply text-small whitespace-nowrap px-4 py-2 font-semibold text-neutral-950;
         @apply transition-colors duration-300 ease-out;
 
         &:hover {
             @apply border-white/70 bg-white/10;
         }
 
-        /* `aria-current` est la seule source de vérité de l'état actif : pas de classe en double. */
+        /*
+            `aria-current` est la seule source de vérité de l'état actif : pas de classe en double.
+
+            Le texte actif est en `color-01-50`, la couleur du fond de la barre, et non en
+            `neutral-1000` : sous `awc-theme-dark` ce dernier vaut blanc, on aurait eu du blanc
+            sur blanc.
+        */
         &[aria-current] {
-            @apply text-neutral-1000 border-white bg-white;
+            @apply text-color-01-50 border-neutral-950 bg-neutral-950;
         }
 
         &:focus-visible {

--- a/resources/views/blocks/action/navbar.blade.php
+++ b/resources/views/blocks/action/navbar.blade.php
@@ -24,7 +24,13 @@
         
         `#sticky-navbar` sert de point d'entrée au script (cf. scripts/blocks/navbar.ts).
     --}}
-    <div class="navbar-anchors" id="sticky-navbar" x-data="initNavBar">
+    {{--
+        `awc-theme-dark` : la barre est une surface sombre du design system (cf. la fiche
+        block-header-topnavbar sur webcomponents.adeliom.io). Les couleurs qu'elle utilise
+        — `color-01-50` pour le fond, `neutral-950` pour les ancres — ne prennent leurs valeurs
+        sombres que sous cette classe.
+    --}}
+    <div class="navbar-anchors awc-theme-dark" id="sticky-navbar" x-data="initNavBar">
         <nav class="navbar-anchors-inner container" aria-label="{{ __('Sommaire de la page', 'horizon-blocks') }}">
             {{--
                 Le scroller et son dégradé de fondu sont dans un wrapper à part : le dégradé se
@@ -50,8 +56,15 @@
                 </ul>
             </div>
 
+            {{--
+                Pas d'icône : `<x-ui.icon>` appelle `@svg($iconName, $class)` avec le `icon-class`
+                du bouton, vide par défaut. Le SVG sortait donc sans classe, la règle
+                `.btn-md .icon { h-3 w-3 }` de button.css ne s'y appliquait pas et il était calculé
+                à 0x0 — tout en restant un élément flex, donc le `gap` du bouton ajoutait 16px de
+                vide à droite du libellé, vers un icône invisible.
+            --}}
             @if (! empty($cta['link']['url']))
-                <x-action.button :fields="$cta" type="secondary" size="medium" icon="fas-arrow-right" class="navbar-anchors-cta" />
+                <x-action.button :fields="$cta" type="secondary" size="medium" class="navbar-anchors-cta" />
             @endif
         </nav>
     </div>


### PR DESCRIPTION
Suite de #37. Deux correctifs sur le bloc barre d'ancres, remontés depuis l'intégration Vénus où la maquette a mis les deux en évidence.

## 1. La barre est une surface sombre du design system

La fiche Figma du composant pointe vers [block-header-topnavbar](https://webcomponents.adeliom.io/?path=/docs/block-header-topnavbar--docs) : ce n'est pas un composant propre à un projet, et le design system le définit avec un fond `color-01-50` et des liens en `neutral-950`.

La barre porte donc `awc-theme-dark`, et son fond passe de `neutral-1000` à `color-01-50`. C'est nécessaire et pas cosmétique : ces couleurs ne prennent leurs valeurs sombres que sous cette classe.

**Deux régressions que ce thème provoquait, corrigées dans le même mouvement :**

| | avant | problème sous `awc-theme-dark` |
|---|---|---|
| texte de l'ancre active | `text-neutral-1000` | `neutral-1000` vaut **blanc** → blanc sur blanc |
| dégradé de fondu du scroller | `var(--color-neutral-1000)` | fondait vers le **blanc** au lieu du fond |

L'ancre active est maintenant en `text-color-01-50` (la couleur du fond de la barre) sur `bg-neutral-950`, et le dégradé pointe sur `--color-color-01-50`.

## 2. L'icône du CTA ajoutait 16px de vide

`<x-ui.icon>` appelle `@svg($iconName, $class)` avec le `icon-class` du bouton, vide par défaut. Le SVG sortait donc **sans aucune classe** — la règle `.btn-md .icon { h-3 w-3 }` de `button.css` ne pouvait pas s'y appliquer, puisqu'elle cible une classe `icon` absente. Résultat : un icône calculé à `0px × 0px`, invisible, mais qui restait un élément flex. Le `gap: 16px` du bouton s'appliquait donc entre le libellé et ce fantôme.

Mesuré dans le navigateur : bouton à **221px** avec l'icône, **205px** sans — soit exactement le gap. La maquette n'en met pas non plus, donc l'icône est retirée.

À noter, ce piège n'est pas propre à ce bloc : tout appel à `x-action.button` avec `icon=` mais sans `icon-class` produit le même effet. Le correctif de fond serait dans `Button.php`, en faisant retomber `$iconClass` sur `'icon'` par défaut — hors périmètre de cette PR, mais ça vaut un ticket.

## Ce qui n'est pas dans cette PR

Le nom de la page à gauche des ancres, que le design system prévoit aussi, reste pour l'instant côté Vénus : il suppose que le bloc vive sur une page dont le titre est signifiant. À arbitrer séparément.

Le design system dessine par ailleurs les ancres en **liens texte** (`16px`, `neutral-950`, sans fond ni bordure) et non en pastilles bordées comme ici. Cet écart est volontairement laissé en place, il demande de définir un état actif que la maquette statique ne montre pas.