### PR TITLE
fix(action): ancres de la navbar en liens texte, gras sur l'active

### DIFF
--- a/docs/superpowers/specs/2026-07-29-faq-vers-accordeon-design.md
+++ b/docs/superpowers/specs/2026-07-29-faq-vers-accordeon-design.md
@@ -1,0 +1,167 @@
+# Bloc FAQ → bloc Accordéon — Design
+
+**Date** : 2026-07-29
+**Auteur** : Emma Louviot
+**Source** : [Notion — Bloc FAQ > le transformer en bloc accordéons](https://app.notion.com/p/31eda39b354280658e67fa14f8b06163)
+**Package** : `agence-adeliom/horizon-blocks`
+**Branche** : `sage/11`
+
+## Objectif
+
+Le bloc FAQ n'est en pratique pas utilisé comme une FAQ, mais comme un accordéon générique. Comme répéter les mêmes questions d'une page à l'autre est une mauvaise pratique SEO, le CPT FAQ n'a plus de raison d'être comme source de contenu.
+
+On transforme donc le bloc en **accordéon** : les paires titre/contenu sont saisies directement dans le bloc via un repeater, le bloc ne dépend plus du CPT FAQ, et le balisage schema.org devient une option explicite.
+
+## Décisions verrouillées pendant le brainstorming
+
+- **Périmètre limité à `horizon-blocks`.** Le CPT FAQ vit dans `agence-adeliom/horizon-posttypes` et **reste en place** : on coupe seulement la dépendance côté bloc. Aucun projet existant ne casse.
+- **Nouveau bloc `accordion`, `FaqBlock` supprimé.** `ImportBlock` copie les blocs dans le projet consommateur en réécrivant les namespaces (`Adeliom\HorizonBlocks\…` → `App\…`), donc chaque projet a déjà sa propre copie sous `App\Blocks\`. Renommer dans la librairie n'affecte que les futurs imports.
+- **schema.org désactivé par défaut.** Le ticket demandait `true` par défaut, mais émettre du `FAQPage` sur tout accordéon générique réintroduit le problème SEO que le ticket cherche à fuir. Le champ existe, il est simplement à `false` par défaut, avec un `helperText` qui explique quand l'activer.
+- **Lignes du repeater** : titre en `Text`, contenu en `WysiwygField::minimal()`.
+- **Accessibilité corrigée dans le même chantier**, le composant étant de toute façon réécrit.
+
+## Périmètre — fichiers
+
+| Action | Fichier |
+|---|---|
+| Créé | `src/Blocks/Content/AccordionBlock.php` |
+| Créé | `src/View/Components/Cards/CardAccordion.php` |
+| Créé | `resources/views/blocks/content/accordion.blade.php` |
+| Créé | `resources/views/components/cards/card-accordion.blade.php` |
+| Créé | `tests/AccordionSchemaTest.php` |
+| Renommé | `resources/images/admin/blocks/content/faq.jpg` → `accordion.jpg` |
+| Renommé | `resources/images/admin/blocks/listing/faq-listing.jpg` → `accordion-listing.jpg` |
+| Supprimé | `src/Blocks/Content/FaqBlock.php` |
+| Supprimé | `src/View/Components/Cards/CardFaq.php` |
+| Supprimé | `resources/views/blocks/content/faq.blade.php` |
+| Supprimé | `resources/views/components/cards/card-faq.blade.php` |
+| Modifié | `src/Services/HorizonBlockService.php` |
+| Modifié | `src/View/Components/Cards/CardStep.php` |
+
+Les images d'admin sont nommées d'après le slug du bloc (`documents.jpg`, `gallery.jpg`, `step.jpg`…), d'où le renommage de `faq.jpg`.
+
+## Champs ACF
+
+`AccordionBlock` reprend l'en-tête de `FaqBlock` à l'identique — `Image` (petite image), `UptitleField`, `HeadingField` en `h2` requis, `WysiwygField::minimal()`, `ButtonField::group()` — et remplace le `Relationship` par :
+
+```php
+Repeater::make(__('Éléments', 'horizon-blocks'), self::FIELD_ITEMS)
+    ->fields([
+        Text::make(__('Titre', 'horizon-blocks'), self::FIELD_ITEM_TITLE)
+            ->maxLength(150)
+            ->helperText(__('Maximum 150 caractères', 'horizon-blocks'))
+            ->required(),
+        WysiwygField::minimal(),
+    ])
+    ->collapsed(self::FIELD_ITEM_TITLE)
+    ->minRows(2)
+    ->button(__('Ajouter un élément', 'horizon-blocks')),
+
+TrueFalseField::make(__('Activer le balisage schema.org (FAQ)', 'horizon-blocks'), self::FIELD_SCHEMA_ORG)
+    ->helperText(__("À n'activer que s'il s'agit d'une véritable FAQ. Sur un accordéon générique, ce balisage peut nuire au référencement.", 'horizon-blocks'))
+    ->default(false),
+```
+
+Constantes : `FIELD_IMG`, `FIELD_ITEMS`, `FIELD_ITEM_TITLE`, `FIELD_SCHEMA_ORG`.
+
+Imports : `Extended\ACF\Fields\Text`, `Extended\ACF\Fields\Repeater`, `Extended\ACF\Fields\Image`, `Adeliom\HorizonTools\Fields\Choices\TrueFalseField` (helper Horizon, comme dans `PostSummaryBlock`, plutôt que le `TrueFalse` brut d'Extended ACF).
+
+**À vérifier à l'implémentation.** `vendor/` n'étant pas installé localement, deux points n'ont pas pu être confirmés dans le code de `horizon-tools` :
+
+1. **Le nom du champ produit par `WysiwygField::minimal()`.** Toutes les occurrences du repo l'appellent sans argument, y compris dans un repeater (`CardsBlock.php:46`), donc la clé de ligne est le nom par défaut du helper — probablement exposé par une constante `WysiwygField::NAME`, sur le modèle de `HeadingField::NAME` utilisé en `->collapsed()`. À confirmer, et à utiliser pour lire le contenu côté `addToContext()` et blade.
+2. **Si le helper accepte `(label, name)`**, on pourra lui passer un `self::FIELD_ITEM_CONTENT` explicite, ce qui serait plus lisible. Sinon on s'en tient à l'appel nu — c'est la convention observée partout dans le repo, donc l'option par défaut.
+
+Ce choix n'a aucun impact sur le reste du design : seule la clé de lecture d'une ligne change.
+
+**Écart assumé par rapport à `CardsBlock`.** Ce bloc utilise `HeadingField::make()` pour le titre de ligne, ce qui expose un sélecteur de balise au rédacteur. Pour un accordéon, le niveau de titre est une décision structurelle (il doit être cohérent avec le `<h2>` du bloc et stable pour `aria-labelledby`), pas un choix éditorial — d'où un `Text` simple. `WysiwygField::minimal()` reste appelé sans argument, conformément à la convention du repo.
+
+**Non repris** : le `maxPosts(5)` de l'ancien `Relationship`. Un accordéon générique n'a pas de raison d'être plafonné à 5 entrées. `minRows(2)` est conservé — un accordéon d'un seul élément n'a pas de sens.
+
+## schema.org
+
+Deux corrections, en plus du toggle.
+
+**1. La structure actuelle est invalide.** `addToContext()` empile des objets `Question` et le blade les sérialise tels quels :
+
+```json
+[ {"@context":"…","@type":"Question",…}, {"@context":"…","@type":"Question",…} ]
+```
+
+Google attend un `FAQPage` dont `mainEntity` contient les `Question`. Un tableau nu au premier niveau, chaque entrée répétant son `@context`, n'est pas exploitable pour les rich results. Nouvelle forme :
+
+```php
+if (empty($fields[self::FIELD_SCHEMA_ORG]) || !SeoService::isCurrentPageIndexed()) {
+    return ['structuredData' => null];
+}
+
+// $questions = [['@type' => 'Question', 'name' => …, 'acceptedAnswer' => ['@type' => 'Answer', 'text' => …]], …]
+return ['structuredData' => $questions === [] ? null : [
+    '@context'   => 'https://schema.org',
+    '@type'      => 'FAQPage',
+    'mainEntity' => $questions,
+]];
+```
+
+**2. `strip_tags()` → `wp_strip_all_tags()`** sur le texte des réponses. Le contenu vient d'un wysiwyg ; `strip_tags` laisse passer le contenu des balises `<script>`/`<style>`, ce que la version WordPress retire.
+
+**Supprimé** : `datePublished`. Il venait de `$questionPost->post_date`, qui n'existe plus sans CPT.
+
+Les lignes dont le titre ou le contenu est vide sont ignorées à la construction, comme aujourd'hui.
+
+## Rendu et accessibilité
+
+`accordion.blade.php` reprend l'en-tête de `faq.blade.php` — y compris le groupe de boutons — et boucle sur `FIELD_ITEMS` en passant des props plates à `<x-cards.card-accordion :title="…" :content="…" />`. Plus d'objet post transmis au composant.
+
+`card-accordion.blade.php` remplace le `<div @click>` actuel par le motif accordéon accessible :
+
+```blade
+@php($uid = wp_unique_id('accordion-'))
+
+<div x-data="{ open: false }" @class(['accordion-item', 'rounded-card bg-color-03-50 p-medium', $attributes['class']])>
+    <h3>
+        <button type="button"
+                id="{{ $uid }}-btn"
+                aria-controls="{{ $uid }}-panel"
+                :aria-expanded="open"
+                @click="open = !open"
+                class="flex justify-between items-center w-full text-left cursor-pointer">
+            <x-typography.text :content="$title" class="font-semibold transition-all" x-bind:class="{ 'text-primary': open }" />
+            <svg aria-hidden="true" :class="{ 'rotate-180': open }" …></svg>
+        </button>
+    </h3>
+    <div id="{{ $uid }}-panel" role="region" aria-labelledby="{{ $uid }}-btn" x-show="open" x-collapse class="pt-medium">
+        <x-typography.text :content="$content" />
+    </div>
+</div>
+```
+
+Points clés : `<button type="button">` (accès clavier et restitution correcte), `aria-expanded` piloté par Alpine, `aria-controls`/`aria-labelledby` appairés, chevron `aria-hidden`, `<h3>` cohérent avec le `<h2>` du bloc. `wp_unique_id()` garantit l'unicité des `id` si plusieurs accordéons cohabitent sur une page.
+
+Chaque panneau reste replié au chargement — comportement actuel, conservé.
+
+## Découplage du CPT FAQ
+
+Dans `HorizonBlockService.php` : l'entrée du bloc perd `REQUIRED_POSTTYPES => [FAQ::class]`, et le `use Adeliom\HorizonPostTypes\PostTypes\FAQ` disparaît. C'est ce qui fait que `ddev acorn import:block` n'installera plus le CPT FAQ dans les nouveaux projets. `COMPONENTS` passe de `[CardFaq::class]` à `[CardAccordion::class]`.
+
+`CardStep.php` porte un `use App\PostTypes\FAQ` **mort** (aucune utilisation dans le fichier) — retiré au passage.
+
+## Tests
+
+`tests/AccordionSchemaTest.php`, aligné sur la forme de `ListingPeriodTest.php`, couvre la seule logique testable sans WordPress — la construction du `FAQPage` :
+
+- toggle à `false` → `structuredData` vaut `null`
+- toggle à `true` → un unique nœud `FAQPage`, un `Question` par ligne, `@context` présent une seule fois
+- lignes au titre ou contenu vide → ignorées
+- toutes les lignes vides → `null` plutôt qu'un `FAQPage` sans `mainEntity`
+
+La logique de construction est extraite dans une méthode statique pure pour être appelable sans bootstrap WordPress, `SeoService::isCurrentPageIndexed()` restant côté `addToContext()`.
+
+## Hors périmètre
+
+- La suppression réelle du CPT FAQ dans `horizon-posttypes`.
+- Toute migration du contenu existant : les projets déjà en production gardent leur copie de `FaqBlock` sous `App\Blocks\` et ne sont pas touchés par ce changement.
+- Le style CSS de l'accordéon, inchangé (les classes actuelles sont conservées, `faq-item` devenant `accordion-item`).
+
+## Point d'attention
+
+La classe utilitaire `faq-item` devient `accordion-item`. Si un projet la cible dans son CSS, le renommage est à répercuter — mais comme les vues sont copiées à l'import, seuls les futurs imports sont concernés.

--- a/resources/styles/blocks/navbar.css
+++ b/resources/styles/blocks/navbar.css
@@ -64,8 +64,9 @@
         }
     }
 
+    /* 28px (`2xlarge`) entre les ancres, comme entre les blocs de la barre. */
     .navbar-anchors-list {
-        @apply flex items-center gap-3 overflow-x-auto;
+        @apply flex items-center gap-7 overflow-x-auto;
 
         /* La barre de défilement alourdirait la barre : on garde le geste, sans le chrome. */
         scrollbar-width: none;
@@ -73,38 +74,63 @@
         &::-webkit-scrollbar {
             @apply hidden;
         }
+
+        /*
+            Ancres centrées dans la place laissée par le CTA, comme dans le design system.
+
+            Le centrage passe par des marges auto et non par `justify-content: center` : en cas
+            de débordement, `center` rend le début de la liste inatteignable au défilement — les
+            premières ancres sont rognées sans pouvoir y revenir. Les marges auto, elles, se
+            réduisent d'elles-mêmes à zéro dès qu'il n'y a plus d'espace libre à absorber.
+        */
+        & > li:first-child {
+            margin-inline-start: auto;
+        }
+
+        & > li:last-child {
+            margin-inline-end: auto;
+        }
     }
 
     /*
-        Pastille d'ancre. Elle reprend le rayon et la graisse des boutons pour s'accorder au CTA
-        voisin, mais pas leurs majuscules : ce sont des libellés de section, parfois longs, que
-        la casse haute rendrait pénibles à lire.
+        Ancre : un lien texte, sans fond ni bordure, conformément au design system. Pas de
+        majuscules non plus — ce sont des libellés de section, parfois longs, que la casse haute
+        rendrait pénibles à lire.
 
         `whitespace-nowrap` : un libellé ne revient jamais à la ligne, c'est la liste qui défile.
     */
     .navbar-anchors-link {
-        /* `inline-flex`, comme le composant `.btn` : un `<a>` reste `inline` par défaut, et la
-           boîte d'un élément inline ne réserve pas sa hauteur — les bordures haute et basse
-           n'étaient pas peintes et la pastille se lisait comme une paire de parenthèses. */
-        @apply inline-flex items-center;
-        /* Bordure à 40 % : en dessous, le contour se perd sur le fond sombre. */
-        @apply rounded-button border border-solid border-white/40;
-        @apply text-small whitespace-nowrap px-4 py-2 font-semibold text-neutral-950;
-        @apply transition-colors duration-300 ease-out;
-
-        &:hover {
-            @apply border-white/70 bg-white/10;
-        }
+        /* Graisse normale au repos : le design system met les liens en semibold, mais l'écart
+           avec le gras de l'ancre active est alors trop ténu pour se lire. */
+        @apply text-medium whitespace-nowrap font-normal text-neutral-950;
+        @apply transition-opacity duration-300 ease-out;
 
         /*
-            `aria-current` est la seule source de vérité de l'état actif : pas de classe en double.
-
-            Le texte actif est en `color-01-50`, la couleur du fond de la barre, et non en
-            `neutral-1000` : sous `awc-theme-dark` ce dernier vaut blanc, on aurait eu du blanc
-            sur blanc.
+            L'ancre active passe en gras, ce qui élargit son libellé — et décalerait toute la
+            rangée à chaque changement de section. On réserve donc en permanence la largeur du
+            gras : le libellé et une copie en gras (`::after`, invisible) partagent la même
+            cellule de grille, dont la largeur est celle du plus large des deux.
         */
+        display: inline-grid;
+
+        & > span,
+        &::after {
+            grid-area: 1 / 1;
+        }
+
+        &::after {
+            @apply invisible font-bold;
+
+            content: attr(data-label);
+        }
+
+        &:hover {
+            @apply opacity-70;
+        }
+
+        /* `aria-current` est la seule source de vérité de l'état actif : pas de classe en double. */
         &[aria-current] {
-            @apply text-color-01-50 border-neutral-950 bg-neutral-950;
+            @apply font-bold;
         }
 
         &:focus-visible {

--- a/resources/views/blocks/action/navbar.blade.php
+++ b/resources/views/blocks/action/navbar.blade.php
@@ -40,6 +40,7 @@
                 <ul class="navbar-anchors-list">
                     @foreach ($anchors as $anchor)
                         @php($link = $anchor[NavbarBlock::FIELD_BUTTON]['link'])
+                        @php($label = $link['title'] ?: $link['url'])
 
                         <li>
                             {{--
@@ -47,9 +48,21 @@
                                 composer avec l'URL absolue que le navigateur renvoie sur
                                 `a.href` (`https://…/page#ancre`), là où il lui faut le seul
                                 fragment. `aria-current` est posé par le script.
+                                
+                                `data-label` reprend le libellé : le CSS s'en sert pour réserver
+                                la largeur du libellé en gras, afin que le passage de l'ancre
+                                active en gras ne décale pas toute la rangée. Le `<span>` est
+                                nécessaire pour que le libellé et cette réserve se superposent
+                                dans la même cellule de grille.
                             --}}
-                            <a href="{{ $link['url'] }}" data-anchor="{{ $link['url'] }}" class="navbar-anchors-link" js-anchor>
-                                {{ $link['title'] ?: $link['url'] }}
+                            <a
+                                href="{{ $link['url'] }}"
+                                data-anchor="{{ $link['url'] }}"
+                                data-label="{{ $label }}"
+                                class="navbar-anchors-link"
+                                js-anchor
+                            >
+                                <span>{{ $label }}</span>
                             </a>
                         </li>
                     @endforeach


### PR DESCRIPTION
Suite de #38. Aligne les ancres sur la définition du design system ([block-header-topnavbar](https://webcomponents.adeliom.io/?path=/docs/block-header-topnavbar--docs)), qui les dessine en **liens texte** et non en pastilles bordées.

## Changements

| | avant | après |
|---|---|---|
| bordure / fond | `border-white/40`, fond au survol | aucun |
| taille | `text-small` (14px) | `text-medium` (16px) |
| espacement | `gap-3` (12px) | `gap-7` (28px) |
| graisse au repos | semibold | **normal** |
| état actif | pastille pleine | **gras** |
| alignement | à gauche | **centré** |

Les liens inactifs passent en graisse normale plutôt qu'en semibold comme le spécifie le design system : l'écart avec le gras de l'active était sinon trop ténu pour se lire d'un coup d'œil.

## Deux pièges traités

**Le gras décalait la rangée.** Passer de normal à gras élargit le libellé, donc toutes les ancres se déplaçaient à chaque changement de section active — un tremblement visible pendant le défilement, alors que c'est justement le moment où l'utilisateur regarde la barre. Une copie invisible du libellé en gras (`::after` alimenté par `data-label`) partage la cellule de grille du libellé et réserve en permanence la largeur du gras. D'où le `display: inline-grid` et le `<span>` autour du libellé.

Vérifié au navigateur : positions et largeurs identiques dans les trois états actifs.

```
actif=#nos-produits    | gauche = [627, 752, 920] | largeurs = [97.8, 140.0, 96.5]
actif=#nos-engagements | gauche = [627, 752, 920] | largeurs = [97.8, 140.0, 96.5]
actif=#nos-services    | gauche = [627, 752, 920] | largeurs = [97.8, 140.0, 96.5]
graisses = [400, 400, 700]
```

**Le centrage ne passe pas par `justify-content: center`.** Sur un conteneur `overflow-x-auto`, `center` rend le début de la liste inatteignable au défilement : les premières ancres sont rognées sans qu'on puisse y revenir. Le centrage se fait donc par des marges auto sur la première et la dernière ancre, qui se réduisent d'elles-mêmes à zéro dès qu'il n'y a plus d'espace libre.

## Toujours hors périmètre

Le nom de la page à gauche des ancres, que le design system prévoit aussi, reste côté projet : il suppose une page dont le titre est signifiant. À arbitrer séparément.