### PR TITLE
fix(listing): render inner cards that carry no data

### DIFF
--- a/src/Livewire/Listing/Listing.php
+++ b/src/Livewire/Listing/Listing.php
@@ -949,7 +949,17 @@ class Listing extends Component
         if (!empty($this->innerCards)) {
             foreach ($this->innerCards as $innerCard) {
                 $card = new ListingInnerCardViewModel();
-                $card->setClass($innerCard['class'] ?? null)->setPosition((int) $innerCard['position'] ?? null);
+                /*
+                    The repeater row is what the card component receives as `fields` (see the view
+                    model's render()), so it doubles as the data every card needs to be rendered.
+                    Without it getData() stayed null on every card.
+                */
+                $card
+                    ->setClass($innerCard['class'] ?? null)
+                    // Parentheses matter: `(int) $x ?? null` casts first, so the coalesce never
+                    // fires and a missing key raises an undefined-key warning instead.
+                    ->setPosition((int) ($innerCard['position'] ?? 0))
+                    ->setData($innerCard);
 
                 if (!empty($innerCard[ListingBlock::FIELD_INNER_CARD_PAGES])) {
                     switch ($innerCard[ListingBlock::FIELD_INNER_CARD_PAGES]) {

--- a/src/ViewModels/ListingInnerCardViewModel.php
+++ b/src/ViewModels/ListingInnerCardViewModel.php
@@ -113,8 +113,9 @@ class ListingInnerCardViewModel
     {
         $html = null;
 
+        // getData() is nullable; the card component expects an array in `fields`.
         if (empty($data)) {
-            $data = $this->getData();
+            $data = $this->getData() ?? [];
         }
 
         $class = $this->getClass();
@@ -139,7 +140,7 @@ class ListingInnerCardViewModel
     public function getHtml(?int $currentPage = null, ?int $perPage = null, array $data = []): ?string
     {
         if (empty($data)) {
-            $data = $this->getData();
+            $data = $this->getData() ?? [];
         }
 
         $this->render(currentPage: $currentPage, perPage: $perPage, data: $data);
@@ -174,7 +175,14 @@ class ListingInnerCardViewModel
         $stdClass->pages = $this->getPages();
         $stdClass->timesAlreadyDisplayed = $this->getTimesAlreadyDisplayed();
         $stdClass->bladeComponentName = $this->getBladeComponentName();
-        $stdClass->html = $this->getHtml(currentPage: $currentPage, perPage: $perPage, data: $this->getData());
+        /*
+            `?? []` is what fixes the crash: getData() is declared ?array, getHtml() takes a
+            non-nullable array, and nothing set data on the card — so every configured inner card
+            hit a TypeError. Coalescing here rather than widening getHtml()'s signature keeps the
+            public API untouched: a project subclassing this view model would fatal on load if a
+            parameter type were relaxed in the parent (PHP forbids narrowing it back in a child).
+        */
+        $stdClass->html = $this->getHtml(currentPage: $currentPage, perPage: $perPage, data: $this->getData() ?? []);
 
         return $stdClass;
     }


### PR DESCRIPTION
Any configured inner card brought the whole listing down with a `TypeError`:

```
ListingInnerCardViewModel::getHtml(): Argument #3 ($data) must be of type array,
null given, called in .../ListingInnerCardViewModel.php on line 177
```

`toStdClass()` forwards `getData()` — declared `?array` — into `getHtml()`, whose `$data` parameter is a non-nullable `array`. Nothing ever called `setData()`, so the value was always `null`: the feature was unusable as shipped. Configure one inner card on a listing and the page 500s.

## Why the call sites and not the signatures

The obvious fix is to relax `render()` and `getHtml()` to `?array`. **That would be a backward-compatibility hazard**: PHP forbids narrowing a parameter type in a child, so any project subclassing this view model and keeping `array $data` would fatal on load the moment the parent widens.

So the coalescing happens at the call sites instead. `getHtml()` and `render()` keep their exact signatures — the public API is untouched — and existing projects get a card that renders instead of a crash as soon as they update.

## Changes

- `toStdClass()` passes `$this->getData() ?? []`;
- `render()` and `getHtml()` coalesce their internal fallback, so `fields` is always an array for the card component;
- `adaptQueryBuilderToListingCards()` sets the repeater row as the card data — that row is what the card receives as `fields`, so cards finally get the data they were meant to get. This file is copied into projects by `import:block`, so it only affects new imports.

Also parenthesised the position cast: `(int) $innerCard['position'] ?? null` casts before the coalesce, so the fallback never fired and a missing key raised an undefined-key warning instead.
