### PR TITLE
refactor(listing): drive the loading state with wire:loading

### DIFF
--- a/resources/scripts/blocks/listing.ts
+++ b/resources/scripts/blocks/listing.ts
@@ -71,21 +71,8 @@ Listing.initInstanceSecondaryFilters = instance => {
     });
 };
 
+// The loading state is handled by wire:loading in the Livewire view, not here.
 Listing.initInstance = instance => {
-    const form = instance.querySelector('form');
-
-    if (form) {
-        form.addEventListener('change', () => {
-            const loading = instance.querySelector('.loading');
-            const results = instance.querySelector('.results');
-
-            if (loading && results) {
-                loading.classList.remove('hidden');
-                results.classList.add('hidden');
-            }
-        });
-    }
-
     Listing.initInstanceSecondaryFilters(instance);
 };
 

--- a/resources/views/livewire/listing/listing.blade.php
+++ b/resources/views/livewire/listing/listing.blade.php
@@ -66,12 +66,21 @@
         <button wire:click="resetFilters">Ré-initialiser</button>
     @endif
 
-    <div class="loading hidden">
+    {{--
+        Loading state driven by wire:loading rather than by a `change` listener on the form: the
+        listener missed page and sort changes, and left the results hidden for good if the request
+        failed. wire:loading reacts to any request made by the component.
+
+        The `is-loading` class is only a hook — projects decide what it looks like. Keeping it on
+        `.results` rather than on a shared parent lets a project blur the results without blurring
+        its own loading indicator.
+    --}}
+    <div class="loading" wire:loading>
         Loading
     </div>
 
     @if(!empty($data['items']))
-        <div class="results">
+        <div class="results" wire:loading.class="is-loading">
             <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
                 @foreach($data['items'] as $post)
                     @if(property_exists($post, 'timesAlreadyDisplayed'))


### PR DESCRIPTION
The loading state was toggled by a `change` listener on the filters form. Three consequences:

- page changes and sort changes never triggered it;
- if a request failed, the results stayed hidden for good;
- it needed ~15 lines of script to do what Livewire does natively.

`wire:loading` reacts to every request the component makes, and needs no script at all.

**What changes for consumers**

- `.loading` drops its `hidden` class — Livewire hides `[wire:loading]` elements itself;
- `.results` gains an `is-loading` class while a request is in flight.

`is-loading` is only a hook: the package ships no styling for it, so projects stay free to decide what loading looks like. It sits on `.results` rather than on a shared parent so a project can blur the results without blurring its own indicator.

Existing projects are not affected until they re-import the block — `import:block` copies the Livewire view and the script into the project.

Split from #40 so the bug fix can land without waiting on this one.
