### PR TITLE
feat(pagination): add an opt-in sliding window and expose ARIA state

### DIFF
--- a/resources/views/components/horizon/pagination.blade.php
+++ b/resources/views/components/horizon/pagination.blade.php
@@ -2,47 +2,65 @@
     @php
         $nextLabel = $nextLabel ?? 'Suivant';
         $previousLabel = $previousLabel ?? 'Précédent';
+        $paginationLabel = $paginationLabel ?? 'Pagination';
 
         $containerClass = $containerClass ?? null;
 
+        /*
+            Opt-in: leaving it false keeps the historical numbering, so projects already running the
+            package see no change. See the comment on the two branches below.
+        */
+        $slidingWindow = $slidingWindow ?? false;
+
         $baseButtonClass =
-            'cursor-pointer block w-10 h-10 rounded flex items-center justify-center transition-opacity duration-200';
-        $inactiveButtonClass = '!cursor-not-allowed opacity-30';
+            'horizon-pagination-arrow cursor-pointer block w-10 h-10 rounded flex items-center justify-center transition-opacity duration-200';
+        $inactiveButtonClass = 'horizon-pagination-arrow-disabled !cursor-not-allowed opacity-30';
 
         $baseNumberClass =
-            'block w-10 h-10 rounded-lg flex items-center justify-center cursor-pointer text-text-secondary font-semibold';
-        $activeNumberClass = 'cursor-default border border-primary rounded';
+            'horizon-pagination-page block w-10 h-10 rounded-lg flex items-center justify-center cursor-pointer text-text-secondary font-semibold';
+        $activeNumberClass = 'horizon-pagination-page-current cursor-default border border-primary rounded';
         $idToScroll = 'listing-container';
 
-        $displayAround = 3;
-        $halfAround = ($displayAround - 1) / 2;
         $separator = '...';
 
-        $pages = $data['pages'];
-        $total = $data['total'];
-        $current = $data['current'];
+        $pages = (int) $data['pages'];
+        $current = (int) $data['current'];
 
         $pageNumbers = [];
-        $pageNumbers[] = 1;
 
-        // Pages proches de la page actuelle (3 pages autour)
-        for ($x = max(2, $current - 1); $x <= min($pages - 1, $current + 1); $x++) {
-            $pageNumbers[] = $x;
-        }
+        if ($slidingWindow) {
+            /*
+                First page, the current page with its direct neighbours, last page. Nothing else:
+                the historical rule below also listed every multiple of five, which carries no
+                meaning for the reader and pushes the pages that do matter out of reach — on 37
+                pages sitting on page 18 it rendered thirteen entries.
+            */
+            $pageNumbers = array_filter([1, $current - 1, $current, $current + 1, $pages], static function (int $page) use ($pages): bool {
+                return $page >= 1 && $page <= $pages;
+            });
+        } else {
+            $pageNumbers[] = 1;
 
-        // Ajouter les multiples de 5
-        for ($x = 5; $x <= $pages; $x += 5) {
-            if (!in_array($x, $pageNumbers)) {
+            // Pages proches de la page actuelle (3 pages autour)
+            for ($x = max(2, $current - 1); $x <= min($pages - 1, $current + 1); $x++) {
                 $pageNumbers[] = $x;
+            }
+
+            // Ajouter les multiples de 5
+            for ($x = 5; $x <= $pages; $x += 5) {
+                if (!in_array($x, $pageNumbers)) {
+                    $pageNumbers[] = $x;
+                }
+            }
+
+            // Ajouter la dernière page si elle n'est pas déjà incluse
+            if (!in_array($pages, $pageNumbers)) {
+                $pageNumbers[] = $pages;
             }
         }
 
-        // Ajouter la dernière page si elle n'est pas déjà incluse
-        if (!in_array($pages, $pageNumbers)) {
-            $pageNumbers[] = $pages;
-        }
-
         // Trier et ajouter les séparateurs
+        $pageNumbers = array_unique($pageNumbers);
         sort($pageNumbers);
         $displayValues = [];
         $last = null;
@@ -80,10 +98,16 @@
     @endphp
 
     @if (!empty($displayValues) && $pages > 1)
-        <div class="flex justify-center gap-4 lg:gap-10{{ $containerClass ? ' '.$containerClass : '' }}">
+        {{--
+            <nav> and not <div>: a set of page links is a navigation landmark, and screen readers
+            announce it as such. The utility classes are unchanged, so the rendering is identical —
+            this is the only change to the DOM structure.
+        --}}
+        <nav class="horizon-pagination flex justify-center gap-4 lg:gap-10{{ $containerClass ? ' '.$containerClass : '' }}"
+             aria-label="{{ $paginationLabel }}">
             @if ($hasButtons)
                 @if ($current > 1)
-                    <a @class([$baseButtonClass]) title="{{ $previousLabel }}"
+                    <a @class([$baseButtonClass]) title="{{ $previousLabel }}" aria-label="{{ $previousLabel }}"
                        href="{{ request()->fullUrlWithQuery(['pagination' => $current - 1]) }}"
                        @click.prevent="scrollToAnchor('{{ $idToScroll }}')"
                        @if ($handle) wire:click.prevent="{{ $handle }}(
@@ -91,24 +115,25 @@
                         <x-far-angle-left class="icon-20" />
                     </a>
                 @else
-                    <span @class([$baseButtonClass, $inactiveButtonClass])>
+                    {{-- Kept in place so the row does not shift by one slot on the first and last pages. --}}
+                    <span @class([$baseButtonClass, $inactiveButtonClass]) aria-hidden="true">
                         <x-far-angle-left class="icon-20" />
                     </span>
                 @endif
             @endif
 
-            <div class="flex items-center">
+            <div class="horizon-pagination-pages flex items-center">
                 @foreach ($displayValues as $page)
                     @if ($page == $current)
-                        <span @class([$baseNumberClass, $activeNumberClass])>{{ $page }}</span>
+                        <span @class([$baseNumberClass, $activeNumberClass]) aria-current="page">{{ $page }}</span>
                     @elseif($page != $separator)
-                        <a @class([$baseNumberClass]) title="Page {{ $page }}"
+                        <a @class([$baseNumberClass]) title="Page {{ $page }}" aria-label="Page {{ $page }}"
                            href="{{ request()->fullUrlWithQuery(['pagination' => $page]) }}"
                            @click.prevent="scrollToAnchor('{{ $idToScroll }}')"
                            @if ($handle) wire:click.prevent="{{ $handle }}(
                            @if($extraHandleParamsFirst && $extraHandleParams) {{ $extraHandleParams }} @endif {{$page}} @if(!$extraHandleParamsFirst && $extraHandleParams) {{$extraHandleParams}} @endif )" @endif>{{ $page }}</a>
                     @else
-                        <span class="my-2 mx-1">{{ $separator }}</span>
+                        <span class="horizon-pagination-ellipsis my-2 mx-1" aria-hidden="true">{{ $separator }}</span>
                     @endif
                 @endforeach
             </div>
@@ -116,7 +141,7 @@
 
             @if ($hasButtons)
                 @if ($current < $pages)
-                    <a @class([$baseButtonClass]) title="{{ $nextLabel }}"
+                    <a @class([$baseButtonClass]) title="{{ $nextLabel }}" aria-label="{{ $nextLabel }}"
                        href="{{ request()->fullUrlWithQuery(['pagination' => $current + 1]) }}"
                        @click.prevent="scrollToAnchor('{{ $idToScroll }}')"
                        @if ($handle) wire:click.prevent="{{ $handle }}(
@@ -124,11 +149,11 @@
                         <x-far-angle-right class="icon-20" />
                     </a>
                 @else
-                    <span @class([$baseButtonClass, $inactiveButtonClass])>
+                    <span @class([$baseButtonClass, $inactiveButtonClass]) aria-hidden="true">
                         <x-far-angle-right class="icon-20" />
                     </span>
                 @endif
             @endif
-        </div>
+        </nav>
     @endif
 @endif


### PR DESCRIPTION
Every change here is inert for a project that updates the package without asking for anything.

## Opt-in numbering

Page numbers were built from the current page and its neighbours **plus every multiple of five**. Those multiples carry no meaning for the reader, and they push the pages that do matter out of reach:

| pages | current | default (unchanged) | `:sliding-window="true"` |
|---|---|---|---|
| 10 | 1 | `[1] 2 … 5 … 10` | `[1] 2 … 10` |
| 12 | 7 | `1 … 5 6 [7] 8 … 10 … 12` | `1 … 6 [7] 8 … 12` |
| 20 | 20 | `1 … 5 … 10 … 15 … 19 [20]` | `1 … 19 [20]` |
| 37 | 18 | `1 … 5 … 10 … 15 … 17 [18] 19 20 … 25 … 30 … 35 … 37` | `1 … 17 [18] 19 … 37` |

`$slidingWindow` defaults to `false`, so **the historical numbering is the default**. I checked that the legacy branch is unchanged rather than assuming it: the original algorithm and the one in this PR return identical page lists across all 1830 `(pages, current)` combinations from 1 to 60 pages.

Opt in per call site:

```blade
<x-horizon.pagination :data="$data" handle="setPage" :has-buttons="true" :sliding-window="true" />
```

The default could flip in a major version — out of scope here.

## Accessibility

Additive, no opt-in:

- `<nav aria-label>` around the links — a set of page links is a navigation landmark;
- `aria-current="page"` on the current page;
- `aria-label` on links and arrows, next to the existing `title`;
- inert arrows and the ellipsis hidden from screen readers.

**The wrapper goes from `<div>` to `<nav>`.** That is the only change to the DOM structure, and it is deliberate — reviewed and accepted by the maintainer of the projects currently running the package. The utility classes are unchanged so the rendering is identical. The one thing worth grepping for before merging: a project selecting this element as `div` rather than by class, e.g. `.some-wrapper > div`.

## Style hooks

`horizon-pagination`, `-pages`, `-page`, `-page-current`, `-arrow`, `-arrow-disabled`, `-ellipsis`, added **next to** the utility classes, none removed. Appearance unchanged.

Namespaced on purpose rather than the shorter `is-current` / `is-disabled`, which could pick up styling a project already applies to those generic names.

The motivation: the component hardcodes its utilities, so a project needing a different look has to fight specificity. On the project this came from, we forked the component into the theme just to turn the current page from an outlined square into a filled pill. With these hooks that fork becomes unnecessary. Moving the utilities out into a stylesheet and leaving the markup classless would be the real cleanup, but it would change the appearance for everyone, so it is left out.

## Also

Dropped `$displayAround`, `$halfAround` and `$total` — computed and never read. Every prop is preserved: `$data`, `$handle`, `$hasButtons`, `$nextLabel`, `$previousLabel`, `$containerClass`, `$extraHandleParams`, `$extraHandleParamsFirst`. The `wire:click`, `href` and Alpine constructs are untouched.

